### PR TITLE
Specify 'source' and 'destination' keys

### DIFF
--- a/docs/configuration/destination_docu/gitea.md
+++ b/docs/configuration/destination_docu/gitea.md
@@ -5,6 +5,7 @@ sidebar_position: 4
 # Gitea
 
 ```yaml title='config'
+destination:
   gitea:
     - token: some-token
       token_file: token.txt

--- a/docs/configuration/destination_docu/github.md
+++ b/docs/configuration/destination_docu/github.md
@@ -5,6 +5,7 @@ sidebar_position: 2
 # Github
 
 ```yaml title="config"
+destination:
   github:
     - token: some-token
       token_file: token.txt

--- a/docs/configuration/destination_docu/gitlab.md
+++ b/docs/configuration/destination_docu/gitlab.md
@@ -5,6 +5,7 @@ sidebar_position: 3
 # Gitlab
 
 ```yaml title="config"
+destination:
   gitlab:
     - token: some-token
       token_file: token.txt

--- a/docs/configuration/destination_docu/gogs.md
+++ b/docs/configuration/destination_docu/gogs.md
@@ -5,6 +5,7 @@ sidebar_position: 5
 # Gogs
 
 ```yaml title="config"
+destination:
   gogs:
     - token: some-token
       token_file: token.txt

--- a/docs/configuration/destination_docu/local.md
+++ b/docs/configuration/destination_docu/local.md
@@ -5,6 +5,7 @@ sidebar_position: 0
 # Local
 
 ```yaml title="config"
+destination:
   local:
     - path: /some/path/gickup
       structured: true

--- a/docs/configuration/destination_docu/onedev.md
+++ b/docs/configuration/destination_docu/onedev.md
@@ -5,6 +5,7 @@ sidebar_position: 6
 # Onedev
 
 ```yaml title="config"
+destination:
   onedev:
     - token: some-token
       token_file: token.txt

--- a/docs/configuration/destination_docu/s3.md
+++ b/docs/configuration/destination_docu/s3.md
@@ -5,6 +5,7 @@ sidebar_position: 9
 # S3
 
 ```yaml title="config"
+destination:
   s3:
    - endpoint: somewhere:9000
      structured: true

--- a/docs/configuration/destination_docu/sourcehut.md
+++ b/docs/configuration/destination_docu/sourcehut.md
@@ -5,6 +5,7 @@ sidebar_position: 7
 # Sourcehut
 
 ```yaml title="config"
+destination:
   sourcehut:
     - token: some-token
       token_file: token.txt

--- a/docs/configuration/source_docu/any.md
+++ b/docs/configuration/source_docu/any.md
@@ -5,6 +5,7 @@ sidebar_position: 7
 # Any
 
 ```yaml title="config"
+source:
   any:
     - token: some-token
       token_file: token.txt

--- a/docs/configuration/source_docu/bitbucket.md
+++ b/docs/configuration/source_docu/bitbucket.md
@@ -5,6 +5,7 @@ sidebar_position: 6
 # Bitbucket
 
 ```yaml title="config"
+source:
   bitbucket:
     - url: http(s)://url-to-bitbucket
       user: some-user

--- a/docs/configuration/source_docu/gitea.md
+++ b/docs/configuration/source_docu/gitea.md
@@ -5,6 +5,7 @@ sidebar_position: 3
 # Gitea
 
 ```yaml title='config'
+source:
   gitea:
     - token: some-token
       token_file: token.txt

--- a/docs/configuration/source_docu/github.md
+++ b/docs/configuration/source_docu/github.md
@@ -5,6 +5,7 @@ sidebar_position: 1
 # Github
 
 ```yaml title="config"
+source:
   github:
     - token: some-token
       token_file: token.txt

--- a/docs/configuration/source_docu/gitlab.md
+++ b/docs/configuration/source_docu/gitlab.md
@@ -5,6 +5,7 @@ sidebar_position: 2
 # Gitlab
 
 ```yaml title="config"
+source:
   gitlab:
     - token: some-token
       token_file: token.txt

--- a/docs/configuration/source_docu/gogs.md
+++ b/docs/configuration/source_docu/gogs.md
@@ -5,6 +5,7 @@ sidebar_position: 3
 # Gogs
 
 ```yaml title="config"
+source:
   gogs:
     - token: some-token
       token_file: token.txt

--- a/docs/configuration/source_docu/onedev.md
+++ b/docs/configuration/source_docu/onedev.md
@@ -5,6 +5,7 @@ sidebar_position: 4
 # Onedev
 
 ```yaml title="config"
+source:
   onedev:
     - token: some-token
       token_file: token.txt

--- a/docs/configuration/source_docu/sourcehut.md
+++ b/docs/configuration/source_docu/sourcehut.md
@@ -5,6 +5,7 @@ sidebar_position: 5
 # Sourcehut
 
 ```yaml title="config"
+source:
   sourcehut:
     - token: some-token
       token_file: token.txt


### PR DESCRIPTION
Currently the source and destination keys are not documented outside of the blog section.

Stating the parent keys for each source/destination makes it clear where in the config file they should be placed.